### PR TITLE
Refactor: Simplify projection starting balance calculation

### DIFF
--- a/pages/DashboardPage.tsx
+++ b/pages/DashboardPage.tsx
@@ -29,18 +29,9 @@ const DashboardPage: React.FC<DashboardPageProps> = ({
   const currentActualBalance = useMemo(() => calculateCurrentActualBalance(transactions), [transactions]);
   
   const projections: ProjectedBalance[] = useMemo(() => {
-    const today = new Date();
-    const yesterday = new Date(today);
-    yesterday.setDate(today.getDate() - 1);
-    const yesterdayStr = yesterday.toISOString().split('T')[0];
-
-    let initialBalanceForProjection = 0;
-    transactions.forEach(t => {
-        if (t.date <= yesterdayStr) {
-            initialBalanceForProjection += t.type === TransactionType.INCOME ? t.amount : -t.amount;
-        }
-    });
-    return calculateProjections(transactions, dailySpending, initialBalanceForProjection, new Date());
+    // The initialBalanceForProjection logic has been removed.
+    // calculateProjections now determines the starting balance from transactions before startDate.
+    return calculateProjections(transactions, dailySpending, new Date());
   }, [transactions, dailySpending]);
 
   const handleAddTransaction = (transaction: Transaction) => {

--- a/services/projectionService.ts
+++ b/services/projectionService.ts
@@ -9,24 +9,18 @@ const formatDate = (date: Date): string => {
 export const calculateProjections = (
   transactions: Transaction[],
   dailySpending: number,
-  initialBalance: number = 0, // If not based on past transactions
+  // initialBalance parameter removed
   startDate: Date = new Date()
 ): ProjectedBalance[] => {
   const projections: ProjectedBalance[] = [];
-  let currentBalance = initialBalance;
+  // let currentBalance = initialBalance; // Old line
 
-  // Calculate actual current balance from past transactions if initialBalance is not explicitly set
-  // For this version, we'll consider transactions on or before 'startDate' to establish the starting point.
-  // A more robust way would be to have a dedicated "Initial Balance" entry.
-  // For now, let's sum up all transactions BEFORE the projection start date to get a starting balance.
-  const todayStr = formatDate(new Date());
-  
-  let effectiveInitialBalance = 0;
+  // Calculate balance from transactions strictly before the projection startDate
+  let balanceAtStartOfProjection = 0;
   transactions.filter(t => t.date < formatDate(startDate)).forEach(t => {
-    effectiveInitialBalance += t.type === TransactionType.INCOME ? t.amount : -t.amount;
+    balanceAtStartOfProjection += t.type === TransactionType.INCOME ? t.amount : -t.amount;
   });
-  currentBalance = effectiveInitialBalance;
-
+  let currentBalance = balanceAtStartOfProjection; // Initialize currentBalance correctly
 
   for (let i = 0; i < PROJECTION_DAYS; i++) {
     const projectionDate = new Date(startDate);
@@ -47,14 +41,10 @@ export const calculateProjections = (
     });
     
     // Apply transactions for the current day to the balance *before* deducting daily spending
-    // If it's the first day of projection (i.e., today), we use the calculated effectiveInitialBalance
+    // If it's the first day of projection (i.e., today), we use the calculated balanceAtStartOfProjection
     // and then apply today's transactions and daily spending.
-    if (i === 0) {
-         currentBalance = currentBalance + dailyIncomes - dailyExpenses - dailySpending;
-    } else {
-         currentBalance = currentBalance + dailyIncomes - dailyExpenses - dailySpending;
-    }
-    
+    // The balance calculation is the same regardless of i === 0 due to pre-calculation of balanceAtStartOfProjection
+    currentBalance = currentBalance + dailyIncomes - dailyExpenses - dailySpending;
 
     projections.push({
       date: dateStr,


### PR DESCRIPTION
I refactored the `calculateProjections` service:
- Removed the unused `initialBalance` parameter.
- The function now always determines its starting balance based on transactions strictly before the `startDate`.
- Renamed `effectiveInitialBalance` to `balanceAtStartOfProjection` for clarity.
- Simplified balance update logic within the projection loop.

I updated `DashboardPage.tsx`:
- Removed the redundant local calculation of `initialBalanceForProjection`.
- Updated the call to `calculateProjections` to reflect its new signature.

These changes make the projection service more autonomous in its calculations and simplify the calling component.