### PR TITLE
feat: Configure project for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your default branch if it's not 'main'
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push to gh-pages branch
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # Specify a Node.js version
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build # This will use the base path from vite.config.ts
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: '/fintrack-app/',
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)


### PR DESCRIPTION
This commit introduces the following changes to enable deployment of the application to GitHub Pages:

1.  **Updated Vite Configuration (`vite.config.ts`):**
    *   Set the `base` path to `/fintrack-app/`. This ensures that all asset URLs are correctly prefixed for deployment to a subdirectory on GitHub Pages.

2.  **Added GitHub Actions Workflow (`.github/workflows/deploy.yml`):**
    *   A new workflow has been added to automate the build and deployment process.
    *   The workflow triggers on pushes to the `main` branch and can also be manually dispatched.
    *   It checks out the code, sets up Node.js, installs dependencies, builds the project (which now uses the correct `base` path), and deploys the contents of the `dist` directory to the `gh-pages` branch using the `peaceiris/actions-gh-pages` action.

These changes address the issue where the application was not rendering correctly on GitHub Pages, likely due to incorrect asset paths. You will need to configure your repository settings to serve the GitHub Pages site from the `gh-pages` branch after this workflow has successfully run.